### PR TITLE
Trim containers

### DIFF
--- a/debian-base/Dockerfile
+++ b/debian-base/Dockerfile
@@ -1,0 +1,20 @@
+FROM mcr.microsoft.com/vscode/devcontainers/base:debian
+
+ENV NONROOT_USER vscode
+ENV DEBIAN_FRONTEND=noninteractive
+# Add ZSH plugins
+RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions \
+    && echo "source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc
+# Install developer tools missing in the base image
+RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+    && curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
+    && apt-get update \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends vim mssql-tools postgresql-client \
+    # Clean up
+    && apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+RUN echo 'export PATH="$PATH:/opt/mssql-tools/bin"' | tee -a /root/.bashrc /root/.zshrc /home/${NONROOT_USER}/.bashrc >> /home/${NONROOT_USER}/.zshrc
+# Copy base scripts
+COPY ./node-debian.sh /usr/local/share
+ENV DEBIAN_FRONTEND=dialog

--- a/debian-base/Dockerfile
+++ b/debian-base/Dockerfile
@@ -9,7 +9,7 @@ RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosu
 RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
     && curl https://packages.microsoft.com/config/ubuntu/18.04/prod.list | tee /etc/apt/sources.list.d/msprod.list \
     && apt-get update \
-    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends vim mssql-tools postgresql-client \
+    && ACCEPT_EULA=Y apt-get install -y --no-install-recommends vim mssql-tools postgresql-client tmux \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/node-debian.sh
+++ b/node-debian.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#-------------------------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
+#-------------------------------------------------------------------------------------------------------------
+
+# Syntax: ./node-debian.sh <directory to install nvm> <node version to install (use "none" to skip)> <non-root user>
+# https://github.com/microsoft/vscode-dev-containers/blob/master/containers/javascript-node/.devcontainer/library-scripts/node-debian.sh
+set -e
+
+export NVM_DIR=${1:-"/usr/local/share/nvm"}
+export NODE_VERSION=${2:-"lts/*"}
+NONROOT_USER=${3:-"vscode"}
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo 'Script must be run a root. Use sudo or set "USER root" before running the script.'
+    exit 1
+fi
+
+# Ensure apt is in non-interactive to avoid prompts
+export DEBIAN_FRONTEND=noninteractive
+
+if [ "${NODE_VERSION}" = "none" ]; then
+    export NODE_VERSION=
+fi
+
+# Install NVM
+mkdir -p ${NVM_DIR}
+curl -so- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash 2>&1
+if [ "${NODE_VERSION}" != "" ]; then
+    /bin/bash -c "source $NVM_DIR/nvm.sh && nvm alias default ${NODE_VERSION}" 2>&1
+fi
+
+echo "export NVM_DIR=\"${NVM_DIR}\"\n\
+[ -s \"\$NVM_DIR/nvm.sh\" ] && \\. \"\$NVM_DIR/nvm.sh\"\n\
+[ -s \"\$NVM_DIR/bash_completion\" ] && \\. \"\$NVM_DIR/bash_completion\"" \
+| tee -a /root/.bashrc /home/${NONROOT_USER}/.bashrc /home/${NONROOT_USER}/.zshrc >> /root/.zshrc
+
+echo "if [ \"\$(stat -c '%U' \$NVM_DIR)\" != \"${NONROOT_USER}\" ]; then\n\
+    sudo chown -R ${NONROOT_USER}:root \$NVM_DIR\n\
+fi" | tee -a /root/.bashrc /root/.zshrc /home/${NONROOT_USER}/.bashrc >> /home/${NONROOT_USER}/.zshrc
+
+chown ${NONROOT_USER}:${NONROOT_USER} /home/${NONROOT_USER}/.bashrc /home/${NONROOT_USER}/.zshrc
+chown -R ${NONROOT_USER}:root ${NVM_DIR}
+
+# Install yarn
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - 2>/dev/null
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list
+apt-get update
+apt-get -y install --no-install-recommends yarn
+apt-get autoremove -y
+apt-get clean -y
+rm -rf /var/lib/apt/lists/*

--- a/node-dev-10/Dockerfile
+++ b/node-dev-10/Dockerfile
@@ -1,6 +1,6 @@
 FROM ukalwa/debian-base
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV NODE_VERSION 12
+ENV NODE_VERSION 10
 RUN /bin/sh /usr/local/share/node-debian.sh /usr/local/share/nvm ${NODE_VERSION}
 ENV DEBIAN_FRONTEND=dialog

--- a/node-dev-14/Dockerfile
+++ b/node-dev-14/Dockerfile
@@ -1,6 +1,6 @@
 FROM ukalwa/debian-base
 
 ENV DEBIAN_FRONTEND=noninteractive
-ENV NODE_VERSION 12
+ENV NODE_VERSION 14
 RUN /bin/sh /usr/local/share/node-debian.sh /usr/local/share/nvm ${NODE_VERSION}
 ENV DEBIAN_FRONTEND=dialog

--- a/python-dev-3.7/Dockerfile
+++ b/python-dev-3.7/Dockerfile
@@ -1,32 +1,26 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:0-3.7
+FROM ukalwa/debian-base
 
 ENV PYTHONUNBUFFERED 1
+ENV NONROOT_USER vscode
 
-# Get latest git
-ENV GIT_VERSION 2.28.0
 ENV DEBIAN_FRONTEND=noninteractive
-RUN apt-get update \
-    && apt-get install -y dh-autoreconf libcurl4-gnutls-dev libexpat1-dev \
-    gettext libz-dev libssl-dev \
-    && curl https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VERSION}.tar.gz -o /tmp/git-${GIT_VERSION}.tar.gz \
-    && cd /tmp && tar -zxf /tmp/git-${GIT_VERSION}.tar.gz && cd git-${GIT_VERSION} \
-    && make configure && ./configure --prefix=/usr && make all \
-    && make install \
-    # Clean up
-    && apt-get remove -y dh-autoreconf libcurl4-gnutls-dev libexpat1-dev \
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/* && rm -rf /tmp/${GIT_VERSION}*
-
-# Install developer tools missing in the base image
-RUN apt-get update \
-    && apt-get install -y vim \
+RUN apt-get update && apt-get install -y python3-pip \
+    && python3 -m pip install pipenv \
+    pylint \
+    flake8 \
+    autopep8 \
+    black \
+    yapf \
+    mypy \
+    pydocstyle \
+    pycodestyle \
+    bandit \
+    virtualenv \
     # Clean up
     && apt-get autoremove -y \
     && apt-get clean -y \
     && rm -rf /var/lib/apt/lists/*
-
-# Add ZSH plugins
-RUN git clone https://github.com/zsh-users/zsh-autosuggestions ~/.zsh/zsh-autosuggestions \
-    && echo "source ~/.zsh/zsh-autosuggestions/zsh-autosuggestions.zsh" >> ~/.zshrc
+# Alias default python to python3
+RUN echo "alias python=python3\nalias pip=pip3\n" \
+    | tee -a /root/.bashrc /home/${NONROOT_USER}/.bashrc /home/${NONROOT_USER}/.zshrc >> /root/.zshrc
 ENV DEBIAN_FRONTEND=dialog


### PR DESCRIPTION
- Create debian base image using debian:buster image
- Use the debian image as the base for all Node images and Python 3.7 image

_Figuring out how to install and build different version of python images without build sizes affecting too much_